### PR TITLE
QOL change to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -218,7 +218,7 @@ echo "$(echo_yellow "NOTE:") Use the shortcut CTRL+B;D to exit the tmux session"
 sleep 5
 
 BASE_DIR=$(get_script_location)
-tmux new "cd \"$BASE_DIR/gem5\" && PYTHON_CONFIG=\"$BASE_DIR/python3.13-config\" M5_OVERRIDE_PY_SOURCE=true nice -n 13 scons build/ALL/gem5.opt"
+tmux new "bash -c \"cd \"$BASE_DIR/gem5\" && PYTHON_CONFIG=\"$BASE_DIR/python3.13-config\" M5_OVERRIDE_PY_SOURCE=true nice -n 13 scons build/ALL/gem5.opt; exec bash\""
 echo
 echo "$(echo_green "Set Up Complete!") You can close this terminal, compilation will complete in the background."
 


### PR DESCRIPTION
Small change to tmux initialization in setup.sh so that the tmux session doesn't exit automatically. This way, build errors aren't lost to the void